### PR TITLE
correct links generation for headers starting with unicode characters

### DIFF
--- a/heading.go
+++ b/heading.go
@@ -76,7 +76,12 @@ var rePunct = regexp.MustCompile(`([^\p{L}\p{M}\p{N}\p{Pc}\- ])`)
 func (h Heading) Anchor() string {
 	// Strip Markdown
 	a := stripmd.Strip(h.Title)
-	a = strings.ToLower(a)
+
+	// When the first character of a heading is an ASCII character (a-z, A-Z),
+	// all the heading should be lowercased.   Otherwise no lowercasing should be performed.
+	if strings.ContainsAny(a[0:1], "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		a = strings.ToLower(a)
+	}
 	a = rePunct.ReplaceAllString(a, "")
 	a = strings.Replace(a, " ", "-", -1)
 	if h.UniqueCounter > 0 {

--- a/test-fixtures/1-insert_basic/preserve-utf8.md.golden
+++ b/test-fixtures/1-insert_basic/preserve-utf8.md.golden
@@ -1,5 +1,5 @@
 - [Title标题](#title标题)
-- [Überschrift](#überschrift)
+- [Überschrift](#Überschrift)
 
 # Title标题
 # Überschrift


### PR DESCRIPTION
When the first character of a heading is an ASCII character (a-z, A-Z),
all the heading should be lowercased.   Otherwise no lowercasing should be performed.

For example, see what links GitHub creates when rendering page https://github.com/nochso/tocenize/blob/master/test-fixtures/1-insert_basic/preserve-utf8.md.  It creates links:

- https://github.com/nochso/tocenize/blob/master/test-fixtures/1-insert_basic/preserve-utf8.md#title标题 .
  It is lowercased because the first character is an ascii character.
- https://github.com/nochso/tocenize/blob/master/test-fixtures/1-insert_basic/preserve-utf8.md#Überschrift.  No lowercasing.

I've been testing these changes for about 4 months mostly on Russian texts.  It works perfectly.