### PR TITLE
don't exit with error in update mode

### DIFF
--- a/cmd/tocenize/main.go
+++ b/cmd/tocenize/main.go
@@ -89,9 +89,6 @@ func runAction(path string, job tocenize.Job, action actionFunc) error {
 	}
 	toc := tocenize.NewTOC(doc, job)
 	newDoc, err := doc.Update(toc, job.ExistingOnly)
-	if newDoc.String() != doc.String() {
-		exitCode = ExitDiff
-	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When tocenize runs in the update mode (default) it exits with non-zero status when one of the files was changed.  It is counterintuitive because usually non-zero exit code is an indicator of an error.